### PR TITLE
fix fieldname for orig as org

### DIFF
--- a/configuration/kibana/visualization/ce69d3d0-27c6-11e8-ae88-194355312858.json
+++ b/configuration/kibana/visualization/ce69d3d0-27c6-11e8-ae88-194355312858.json
@@ -1,10 +1,10 @@
 {
   "title": "CONN - Top Originating ASN",
-  "visState": "{\"title\":\"CONN - Top Originating ASN\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"conn.orig_asn\",\"otherBucket\":true,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\",\"size\":9,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Originating ASN\"}}]}",
+  "visState": "{\"title\":\"CONN - Top Originating ASN\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"@meta.geoip_orig.as_org\",\"otherBucket\":true,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\",\"size\":9,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Originating ASN\"}}]}",
   "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}",
   "description": "",
   "savedSearchId": "009f6e00-2024-11e8-82ea-3daef40316d8",
-  "version": 1,
+  "version": 2,
   "kibanaSavedObjectMeta": {
     "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
   }


### PR DESCRIPTION
Correct the orig_h geo as org field name, field name is now "@meta.geoip_orig.as_org".
Dashboard for CONN - Counts currently displays errors otherwise