### PR TITLE
fix bro dhcp log

### DIFF
--- a/configuration/logstash/logstash-500-filter-bro.conf
+++ b/configuration/logstash/logstash-500-filter-bro.conf
@@ -75,7 +75,7 @@ filter {
           "id_resp_p" => "integer"
           }
           add_field => {
-            "[@meta][event_type]" => "network"
+            "[@meta][evshent_type]" => "network"
             "[@meta][id]" => "%{uid}"
             "[@meta][orig_host]" => "%{id_orig_h}"
             "[@meta][orig_port]" => "%{id_orig_p}"
@@ -136,9 +136,6 @@ filter {
       if [id_resp_h] {
         mutate { merge => { "[@meta][related_ips]" => "id_resp_h" }}
       }
-      if [assigned_ip] {
-        mutate { merge => { "[@meta][related_ips]" => "assigned_ip" }}
-      }
       if [rx_hosts] {
         mutate { merge => { "[@meta][related_ips]" => "rx_hosts" }}
       }
@@ -178,5 +175,52 @@ filter {
         "
       }
       mutate { add_field => {"[@metadata][stage]" => "broraw_kafka" } }
+
+      # Temporary fix for DHCP
+      if [@meta][stream] == "dhcp" and [@metadata][stage] == "broraw_kafka" {
+      
+        mutate {
+          remove_field => [
+            "id_orig_h",
+            "id_orig_p",
+            "id_resp_h",
+            "id_resp_p",
+            "[@meta][orig_host]",
+            "[@meta][orig_port]",
+            "[@meta][resp_host]",
+            "[@meta][resp_port]",
+            "[@meta][related_ips]"
+          ]
+        }
+        
+        # Recreate related IPs and Fix Orig/Resp Host (Client/Server)
+        mutate { add_field => { "[@meta][related_ips]" => [] } }
+
+        if [dhcp][client_addr] {
+          mutate {
+            merge => { "[@meta][related_ips]" => "[dhcp][client_addr]" }
+            add_field => { "[@meta][orig_host]" => "%{[dhcp][client_addr]}" }
+          }
+        }
+		
+        if [dhcp][server_addr] {
+          mutate {
+            merge => { "[@meta][related_ips]" => "[dhcp][server_addr]" }
+            add_field => { "[@meta][resp_host]" => "%{[dhcp][server_addr]}" }
+          }
+        }
+
+        if [dhcp][assigned_addr] {
+          mutate { merge => { "[@meta][related_ips]" => "assigned_addr" } }
+        }
+
+        if [dhcp][msg_orig] {
+          mutate { merge => { "[@meta][related_ips]" => "msg_orig" } }
+        }
+
+        if [dhcp][requested_addr] {
+          mutate { merge => { "[@meta][related_ips]" => "requested_addr" } }
+        }
+      }
   }
 }


### PR DESCRIPTION
Fixes:
- resp_p and orig_p do not exist in dhcp.log __ removed the fields
- orig_host and resp_host do not exist in dhcp.lg __ remove the fields
- meta field for orig host/port & resp host/port __ remove the fields
- meta related_ips gets jammed because above __ remove field
- assigned_ip doesn't exist __ fix using assigned_addr
- recreate meta orig host using client_addr
- recreate meta resp host using server_addr
- add the 5 (possible) IP fields in DCHP to meta related_ips