### PR TITLE
Update Observer and Sensor Version

### DIFF
--- a/ecs-configuration/logstash/conf.d/logstash-499-filter-rock-environment.conf
+++ b/ecs-configuration/logstash/conf.d/logstash-499-filter-rock-environment.conf
@@ -37,8 +37,8 @@ filter {
     add_field => {
       "[observer][type]" => "sensor"
       "[observer][vendor]" => "RockNSM"
-      "[observer][version]" => "2.6.3"
-      "[observer][sensor_version]" => "${LS_ROCKNSM_VERSION:2.4}"
+      "[observer][version]" => "3.0.1"
+      "[observer][sensor_version]" => "${LS_ROCKNSM_VERSION:2.5.1}"
     }
   }
 }


### PR DESCRIPTION
Currently, in `logstash-499-filter-rock-environment` the `observer.version{sensor_version}` is set to an older version of Zeek and ROCK.

I have updated them to `3.0.1` and `2.5.1`.

Delete this branch upon merge.