### PR TITLE
replaced bro with zeek to match kafka

### DIFF
--- a/ecs-configuration/logstash/conf.d/logstash-100-input-kafka-zeek.conf
+++ b/ecs-configuration/logstash/conf.d/logstash-100-input-kafka-zeek.conf
@@ -1,6 +1,6 @@
 input {
   kafka {
-    topics => ["bro-raw"]
+    topics => ["zeek-raw"]
     add_field => { "[@metadata][stage]" => "zeek_json" }
     # Set this to one per kafka partition to scale up
     #consumer_threads => 4


### PR DESCRIPTION
Logstash is looking for the old topic `bro-raw`. It should be looking for `zeek-raw`